### PR TITLE
Dockerfile updates: healthcheck, `--no-install-recommends`

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,16 +3,8 @@ FROM ghcr.io/astral-sh/uv:python3.13-bookworm
 RUN apt-get update \
   && apt-get install -y --no-install-recommends netcat-traditional git \
   && rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man \
-  && apt-get clean
-
-# Create non-root user to run the app
-RUN groupadd -g 1000 app \
-  && useradd -m -u 1000 -g app -s /bin/bash app \
-  && mkdir -p /backend /backend/staticfiles /home/app/.cache/uv \
-  && chown -R app:app /backend /home/app/.cache/uv
-
-# Switch to the non-root user
-USER app
+  && apt-get clean \
+  && mkdir /backend
 
 # Set the working directory inside the container
 WORKDIR /backend
@@ -26,15 +18,15 @@ ENV PYTHONUNBUFFERED=1
 ENV UV_LINK_MODE=copy
 
 # Install the project's dependencies using the lockfile and settings
-RUN --mount=type=cache,target=/home/app/.cache/uv,uid=1000,gid=1000 \
+RUN --mount=type=cache,target=/root/.cache/uv \
   --mount=type=bind,source=uv.lock,target=uv.lock \
   --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
   uv sync --locked --no-install-project
 
 # Then, add the rest of the project source code and install it
 # Installing separately from its dependencies allows optimal layer caching
-COPY --chown=app:app . /backend
-RUN --mount=type=cache,target=/home/app/.cache/uv,uid=1000,gid=1000 \
+COPY . /backend
+RUN --mount=type=cache,target=/root/.cache/uv \
   uv sync --locked
 
 # Expose the Django port

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,10 +1,18 @@
 FROM ghcr.io/astral-sh/uv:python3.13-bookworm
 
 RUN apt-get update \
-  && apt-get install -y netcat-traditional git \
+  && apt-get install -y --no-install-recommends netcat-traditional git \
   && rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man \
-  && apt-get clean \
-  && mkdir /backend
+  && apt-get clean
+
+# Create non-root user to run the app
+RUN groupadd -g 1000 app \
+  && useradd -m -u 1000 -g app -s /bin/bash app \
+  && mkdir -p /backend /backend/staticfiles /home/app/.cache/uv \
+  && chown -R app:app /backend /home/app/.cache/uv
+
+# Switch to the non-root user
+USER app
 
 # Set the working directory inside the container
 WORKDIR /backend
@@ -18,16 +26,16 @@ ENV PYTHONUNBUFFERED=1
 ENV UV_LINK_MODE=copy
 
 # Install the project's dependencies using the lockfile and settings
-RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=uv.lock,target=uv.lock \
-    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --locked --no-install-project
+RUN --mount=type=cache,target=/home/app/.cache/uv,uid=1000,gid=1000 \
+  --mount=type=bind,source=uv.lock,target=uv.lock \
+  --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+  uv sync --locked --no-install-project
 
 # Then, add the rest of the project source code and install it
 # Installing separately from its dependencies allows optimal layer caching
-COPY . /backend
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked
+COPY --chown=app:app . /backend
+RUN --mount=type=cache,target=/home/app/.cache/uv,uid=1000,gid=1000 \
+  uv sync --locked
 
 # Expose the Django port
 EXPOSE 8000
@@ -37,6 +45,13 @@ ENTRYPOINT []
 
 # Add permissions to the entrypoint script
 RUN chmod +x /backend/entrypoint.sh
+
+# Add a healthcheck to verify the app responds on /api/status
+HEALTHCHECK --start-period=20s \
+  CMD python -c "import sys,urllib.request; \
+  url='http://127.0.0.1:8000/api/status'; \
+  resp=urllib.request.urlopen(url, timeout=3); \
+  sys.exit(0 if 200 <= resp.getcode() < 300 else 1)" || exit 1
 
 # Run Django's development server
 CMD ["/bin/bash", "/backend/entrypoint.sh"]

--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -42,6 +42,8 @@ services:
       - postgres
     volumes:
       - ./backend:/backend
+      - /backend/.venv
+      - /backend/staticfiles
     networks:
       - app_network
 

--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -43,7 +43,6 @@ services:
     volumes:
       - ./backend:/backend
       - /backend/.venv
-      - /backend/staticfiles
     networks:
       - app_network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,9 +25,8 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ./backend:/backend
+      - ./backend:/backend:delegated
       - /backend/.venv
-      - /backend/staticfiles
     networks:
       - app_network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,9 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ./backend:/backend:delegated
+      - ./backend:/backend
       - /backend/.venv
+      - /backend/staticfiles
     networks:
       - app_network
 


### PR DESCRIPTION
- Install deps with the `--no-install-recommends` flag
- Add a healthcheck
- <del>Switch Dockerfile to use non-root</del> (In containers with host bind mounts, running as non‑root can cause permission conflicts because host filesystem ownership overrides container user permissions)