### PR TITLE
Gunicorn with uvicorn workers

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,16 +1,23 @@
 #!/bin/bash
-set -e  # Stop the script if any command fails
+set -euo pipefail # Stop the script if any command fails
 
 echo "Migrating database"
 uv run manage.py migrate --noinput
 
 # Choose the server based on DEBUG
 if [[ "$DEBUG" =~ ^(1|true|True|TRUE|on|yes)$ ]]; then
-  echo "Starting Django development server"
-  uv run manage.py runserver 0.0.0.0:8000
+    echo "Starting Django development server"
+    uv run manage.py runserver 0.0.0.0:8000
 else
-  echo "Collecting static files"
-  uv run manage.py collectstatic --noinput
-  echo "Starting Uvicorn server"
-  uv run uvicorn config.asgi:application --host 0.0.0.0 --port 8000
+    echo "Collecting static files"
+    uv run manage.py collectstatic --noinput
+    echo "Starting Uvicorn server"
+    exec uv run gunicorn config.asgi:application \
+    --bind 0.0.0.0:"${PORT:-8000}" \
+    --workers "${WEB_CONCURRENCY:-2}" \
+    --worker-class uvicorn_worker.UvicornWorker \
+    --access-logfile - \
+    --error-logfile - \
+    --timeout "${GUNICORN_TIMEOUT:-60}" \
+    --keep-alive "${GUNICORN_KEEPALIVE:-5}"
 fi

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -11,7 +11,7 @@ if [[ "$DEBUG" =~ ^(1|true|True|TRUE|on|yes)$ ]]; then
 else
     echo "Collecting static files"
     uv run manage.py collectstatic --noinput
-    echo "Starting Uvicorn server"
+    echo "Starting Gunicorn server"
     exec uv run gunicorn config.asgi:application \
     --bind 0.0.0.0:"${PORT:-8000}" \
     --workers "${WEB_CONCURRENCY:-2}" \

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "polygon-api-client>=1.15.3",
     "psycopg>=3.2.9",
     "pydantic>=2.11.6",
+    "uvicorn-worker>=0.3.0",
     "uvicorn>=0.34.3",
     "whitenoise>=6.9.0",
     "yfinance>=0.2.63",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -495,6 +495,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/04/13/d9839089b900fa7b479cce495d62110cddc4bd5630a04d8469916c0e79c5/frozendict-2.4.6-py311-none-any.whl", hash = "sha256:d065db6a44db2e2375c23eac816f1a022feb2fa98cbb50df44a9e83700accbea", size = 16148, upload-time = "2024-10-13T12:15:26.839Z" },
     { url = "https://files.pythonhosted.org/packages/ba/d0/d482c39cee2ab2978a892558cf130681d4574ea208e162da8958b31e9250/frozendict-2.4.6-py312-none-any.whl", hash = "sha256:49344abe90fb75f0f9fdefe6d4ef6d4894e640fadab71f11009d52ad97f370b9", size = 16146, upload-time = "2024-10-13T12:15:28.16Z" },
     { url = "https://files.pythonhosted.org/packages/a5/8e/b6bf6a0de482d7d7d7a2aaac8fdc4a4d0bb24a809f5ddd422aa7060eb3d2/frozendict-2.4.6-py313-none-any.whl", hash = "sha256:7134a2bb95d4a16556bb5f2b9736dceb6ea848fa5b6f3f6c2d6dba93b44b4757", size = 16146, upload-time = "2024-10-13T12:15:29.495Z" },
+]
+
+[[package]]
+name = "gunicorn"
+version = "23.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/72/9614c465dc206155d93eff0ca20d42e1e35afc533971379482de953521a4/gunicorn-23.0.0.tar.gz", hash = "sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec", size = 375031, upload-time = "2024-08-10T20:25:27.378Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/7d/6dac2a6e1eba33ee43f318edbed4ff29151a49b5d37f080aad1e6469bca4/gunicorn-23.0.0-py3-none-any.whl", hash = "sha256:ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d", size = 85029, upload-time = "2024-08-10T20:25:24.996Z" },
 ]
 
 [[package]]
@@ -1192,6 +1204,7 @@ dependencies = [
     { name = "psycopg" },
     { name = "pydantic" },
     { name = "uvicorn" },
+    { name = "uvicorn-worker" },
     { name = "whitenoise" },
     { name = "yfinance" },
 ]
@@ -1234,6 +1247,7 @@ requires-dist = [
     { name = "psycopg", specifier = ">=3.2.9" },
     { name = "pydantic", specifier = ">=2.11.6" },
     { name = "uvicorn", specifier = ">=0.34.3" },
+    { name = "uvicorn-worker", specifier = ">=0.3.0" },
     { name = "whitenoise", specifier = ">=6.9.0" },
     { name = "yfinance", specifier = ">=0.2.63" },
 ]
@@ -1440,6 +1454,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/de/ad/713be230bcda622eaa35c28f0d328c3675c371238470abdea52417f17a8e/uvicorn-0.34.3.tar.gz", hash = "sha256:35919a9a979d7a59334b6b10e05d77c1d0d574c50e0fc98b8b1a0f165708b55a", size = 76631, upload-time = "2025-06-01T07:48:17.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/0d/8adfeaa62945f90d19ddc461c55f4a50c258af7662d34b6a3d5d1f8646f6/uvicorn-0.34.3-py3-none-any.whl", hash = "sha256:16246631db62bdfbf069b0645177d6e8a77ba950cfedbfd093acef9444e4d885", size = 62431, upload-time = "2025-06-01T07:48:15.664Z" },
+]
+
+[[package]]
+name = "uvicorn-worker"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gunicorn" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/c0/b5df8c9a31b0516a47703a669902b362ca1e569fed4f3daa1d4299b28be0/uvicorn_worker-0.3.0.tar.gz", hash = "sha256:6baeab7b2162ea6b9612cbe149aa670a76090ad65a267ce8e27316ed13c7de7b", size = 9181, upload-time = "2024-12-26T12:13:07.591Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/1f/4e5f8770c2cf4faa2c3ed3c19f9d4485ac9db0a6b029a7866921709bdc6c/uvicorn_worker-0.3.0-py3-none-any.whl", hash = "sha256:ef0fe8aad27b0290a9e602a256b03f5a5da3a9e5f942414ca587b645ec77dd52", size = 5346, upload-time = "2024-12-26T12:13:06.026Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Summary
- switch production server to Gunicorn with UvicornWorker
- replace pure Uvicorn run in `entrypoint.sh`
- add uvicorn-worker deps
- harden startup (set -euo pipefail, exec, env-driven PORT/WEB_CONCURRENCY/timeout)

## Related Issues
Closes #52 