### PR TITLE
Refactor/move stats mocks

### DIFF
--- a/backend/modules/investors/serializers.py
+++ b/backend/modules/investors/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from backend.modules.core import defaults
+from modules.core import defaults
 from modules.investors.models import Investor
 
 
@@ -66,9 +66,9 @@ class AccountValueOverTimeSerializer(serializers.Serializer):
 
 
 class CurrentAccountValueSerializer(serializers.Serializer):
-    total_account_value = defaults.DecimalField(decimal_places=2)
-    gain = defaults.DecimalField(decimal_places=2)
-    gain_percent = defaults.DecimalField(decimal_places=2)
+    total_account_value = serializers.FloatField()
+    gain = serializers.FloatField()
+    gain_percent = serializers.FloatField()
 
 
 class AssetAllocationItemSerializer(serializers.Serializer):
@@ -106,9 +106,9 @@ class TradingOverviewSerializer(serializers.Serializer):
     total_trades = serializers.IntegerField()
     buys = serializers.IntegerField()
     sells = serializers.IntegerField()
-    avg_gain = defaults.DecimalField(decimal_places=2)
-    avg_loss = defaults.DecimalField(decimal_places=2)
-    total_return = defaults.DecimalField(decimal_places=2)
+    avg_gain = serializers.FloatField()
+    avg_loss = serializers.FloatField()
+    total_return = serializers.FloatField()
     
 
 class MostTradedItemSerializer(serializers.Serializer):
@@ -116,9 +116,9 @@ class MostTradedItemSerializer(serializers.Serializer):
     no_trades = serializers.IntegerField()
     buys = serializers.IntegerField()
     sells = serializers.IntegerField()
-    avg_gain = defaults.DecimalField(decimal_places=2)
-    avg_loss = defaults.DecimalField(decimal_places=2)
-    total_return = defaults.DecimalField(decimal_places=2)
+    avg_gain = serializers.FloatField()
+    avg_loss = serializers.FloatField()
+    total_return = serializers.FloatField()
 
 class MostTradedOverviewSerializer(serializers.Serializer):
     instruments = MostTradedItemSerializer(many=True)

--- a/backend/modules/investors/serializers.py
+++ b/backend/modules/investors/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+from backend.modules.core import defaults
 from modules.investors.models import Investor
 
 
@@ -65,7 +66,9 @@ class AccountValueOverTimeSerializer(serializers.Serializer):
 
 
 class CurrentAccountValueSerializer(serializers.Serializer):
-    value = serializers.FloatField()
+    total_account_value = defaults.DecimalField(decimal_places=2)
+    gain = defaults.DecimalField(decimal_places=2)
+    gain_percent = defaults.DecimalField(decimal_places=2)
 
 
 class AssetAllocationItemSerializer(serializers.Serializer):
@@ -91,3 +94,32 @@ class OwnedShareItemSerializer(serializers.Serializer):
 
 class OwnedSharesSerializer(serializers.Serializer):
     owned_shares = OwnedShareItemSerializer(many=True)
+
+
+class ProfileOverviewSerializer(serializers.Serializer):
+    level = serializers.CharField(max_length=30)
+    exp_points = serializers.IntegerField()
+    left_to_next_level = serializers.IntegerField()
+
+
+class TradingOverviewSerializer(serializers.Serializer):
+    total_trades = serializers.IntegerField()
+    buys = serializers.IntegerField()
+    sells = serializers.IntegerField()
+    avg_gain = defaults.DecimalField(decimal_places=2)
+    avg_loss = defaults.DecimalField(decimal_places=2)
+    total_return = defaults.DecimalField(decimal_places=2)
+    
+
+class MostTradedItemSerializer(serializers.Serializer):
+    symbol = serializers.CharField(max_length=10)
+    no_trades = serializers.IntegerField()
+    buys = serializers.IntegerField()
+    sells = serializers.IntegerField()
+    avg_gain = defaults.DecimalField(decimal_places=2)
+    avg_loss = defaults.DecimalField(decimal_places=2)
+    total_return = defaults.DecimalField(decimal_places=2)
+
+class MostTradedOverviewSerializer(serializers.Serializer):
+    instruments = MostTradedItemSerializer(many=True)
+    

--- a/backend/modules/investors/serializers.py
+++ b/backend/modules/investors/serializers.py
@@ -1,6 +1,5 @@
 from rest_framework import serializers
 
-from modules.core import defaults
 from modules.investors.models import Investor
 
 
@@ -109,7 +108,7 @@ class TradingOverviewSerializer(serializers.Serializer):
     avg_gain = serializers.FloatField()
     avg_loss = serializers.FloatField()
     total_return = serializers.FloatField()
-    
+
 
 class MostTradedItemSerializer(serializers.Serializer):
     symbol = serializers.CharField(max_length=10)
@@ -120,6 +119,6 @@ class MostTradedItemSerializer(serializers.Serializer):
     avg_loss = serializers.FloatField()
     total_return = serializers.FloatField()
 
+
 class MostTradedOverviewSerializer(serializers.Serializer):
     instruments = MostTradedItemSerializer(many=True)
-    

--- a/backend/modules/investors/urls.py
+++ b/backend/modules/investors/urls.py
@@ -8,7 +8,10 @@ from modules.investors.views import (
     InvestorDetailView,
     InvestorListView,
     InvestorStatsView,
+    MostTradedOverviewView,
     OwnedSharesView,
+    ProfileOverviewView,
+    TradingOverviewView,
 )
 
 app_name = "investors"
@@ -34,4 +37,7 @@ urlpatterns = [
         name="asset-allocation",
     ),
     path("me/owned-shares", OwnedSharesView.as_view(), name="owned-shares"),
+    path("me/statistics/most-traded", MostTradedOverviewView.as_view(), name="most-traded"),
+    path("me/statistics/profile", ProfileOverviewView.as_view(), name="profile-overview"),
+    path("me/statistics/overview", TradingOverviewView.as_view(), name="trading-overview"),
 ]

--- a/backend/modules/investors/urls.py
+++ b/backend/modules/investors/urls.py
@@ -19,7 +19,6 @@ app_name = "investors"
 urlpatterns = [
     path("", InvestorListView.as_view(), name="investor-list-create"),
     path("me/", CurrentInvestorView.as_view(), name="current-investor"),
-    path("<str:clerk_id>/", InvestorDetailView.as_view(), name="investor-detail"),
     path("me/stats/", InvestorStatsView.as_view(), name="investor-stats"),
     path(
         "me/account-value/",
@@ -32,12 +31,13 @@ urlpatterns = [
         name="current-account-value",
     ),
     path(
-        "me/asset-allocation",
+        "me/asset-allocation/",
         AssetAllocationView.as_view(),
         name="asset-allocation",
     ),
-    path("me/owned-shares", OwnedSharesView.as_view(), name="owned-shares"),
-    path("me/statistics/most-traded", MostTradedOverviewView.as_view(), name="most-traded"),
-    path("me/statistics/profile", ProfileOverviewView.as_view(), name="profile-overview"),
-    path("me/statistics/overview", TradingOverviewView.as_view(), name="trading-overview"),
+    path("me/owned-shares/", OwnedSharesView.as_view(), name="owned-shares"),
+    path("me/statistics/most-traded/", MostTradedOverviewView.as_view(), name="most-traded"),
+    path("me/statistics/profile-overview/", ProfileOverviewView.as_view(), name="profile-overview"),
+    path("me/statistics/trading-overview/", TradingOverviewView.as_view(), name="trading-overview"),
+    path("<str:clerk_id>/", InvestorDetailView.as_view(), name="investor-detail"),
 ]

--- a/backend/modules/investors/urls.py
+++ b/backend/modules/investors/urls.py
@@ -36,8 +36,20 @@ urlpatterns = [
         name="asset-allocation",
     ),
     path("me/owned-shares/", OwnedSharesView.as_view(), name="owned-shares"),
-    path("me/statistics/most-traded/", MostTradedOverviewView.as_view(), name="most-traded"),
-    path("me/statistics/profile-overview/", ProfileOverviewView.as_view(), name="profile-overview"),
-    path("me/statistics/trading-overview/", TradingOverviewView.as_view(), name="trading-overview"),
+    path(
+        "me/statistics/most-traded/",
+        MostTradedOverviewView.as_view(),
+        name="most-traded",
+    ),
+    path(
+        "me/statistics/profile-overview/",
+        ProfileOverviewView.as_view(),
+        name="profile-overview",
+    ),
+    path(
+        "me/statistics/trading-overview/",
+        TradingOverviewView.as_view(),
+        name="trading-overview",
+    ),
     path("<str:clerk_id>/", InvestorDetailView.as_view(), name="investor-detail"),
 ]

--- a/backend/modules/investors/views.py
+++ b/backend/modules/investors/views.py
@@ -217,9 +217,9 @@ class CurrentAccountValueView(generics.RetrieveAPIView):
         gain_percent = 100 * gain / start_account_value
 
         response = {
-            "total_account_value" : round(value, 2),
-            "gain" : round(gain,2),
-            "gain_percent" : round(gain_percent,2)
+            "total_account_value": round(value, 2),
+            "gain": round(gain, 2),
+            "gain_percent": round(gain_percent, 2),
         }
 
         serializer = self.get_serializer(response)
@@ -228,7 +228,10 @@ class CurrentAccountValueView(generics.RetrieveAPIView):
     @extend_schema(
         responses={200: CurrentAccountValueSerializer},
         summary="Get current account value",
-        description="Get the current account value as well as gain and percent gain for the authenticated user.",
+        description=(
+            "Get the current account value as well as gain and percent gain "
+            "for the authenticated user."
+        ),
     )
     def get(self, request: Request, *args, **kwargs) -> Response:
         return super().get(request, *args, **kwargs)
@@ -398,7 +401,7 @@ class ProfileOverviewView(generics.RetrieveAPIView):
     def retrieve(self, request, *args, **kwargs):
         random.seed(hash(self.request.user.id))
         response = {
-            "level" : "Newbie",
+            "level": "Newbie",
             "exp_points": random.randint(500, 1000),
             "left_to_next_level": random.randint(100, 300),
         }
@@ -409,7 +412,10 @@ class ProfileOverviewView(generics.RetrieveAPIView):
     @extend_schema(
         responses={200: ProfileOverviewSerializer},
         summary="Get info about investor's level",
-        description="Get the information about the level, exp points and points left to next level for the current investor",
+        description=(
+            "Get the information about the level, exp points"
+            " and points left to next level for the current investor"
+        ),
     )
     def get(self, request: Request, *args, **kwargs) -> Response:
         return super().get(request, *args, **kwargs)
@@ -432,8 +438,8 @@ class TradingOverviewView(generics.RetrieveAPIView):
             "buys": buys,
             "sells": no_trades - buys,
             "avg_gain": round(random.uniform(1, 50), 2),
-            "avg_loss":  round(random.uniform(1, 50), 2),
-            "total_return":  round(random.uniform(500, 2000), 2),
+            "avg_loss": round(random.uniform(1, 50), 2),
+            "total_return": round(random.uniform(500, 2000), 2),
         }
 
         serializer = self.get_serializer(response)
@@ -442,7 +448,10 @@ class TradingOverviewView(generics.RetrieveAPIView):
     @extend_schema(
         responses={200: TradingOverviewSerializer},
         summary="Get trading performance overview",
-        description="Returns total trades, number of buys/sells, average gain/loss, and total return for the current investor."
+        description=(
+            "Returns total trades, number of buys/sells, average gain/loss, "
+            "and total return for the current investor."
+        ),
     )
     def get(self, request: Request, *args, **kwargs) -> Response:
         return super().get(request, *args, **kwargs)
@@ -476,14 +485,16 @@ class MostTradedOverviewView(generics.RetrieveAPIView):
             }
             instruments.append(instrument)
 
-
         serializer = self.get_serializer({"instruments": instruments})
         return Response(serializer.data)
 
     @extend_schema(
         responses={200: MostTradedOverviewSerializer},
         summary="Get overview about the most traded instruments",
-        description="Returns number of trades, number of buys/sells, average gain/loss, and total return from the most frequently traded instruments."
+        description=(
+            "Returns number of trades, number of buys/sells, avg gain/loss, "
+            "and total return from the most frequently traded instruments."
+        ),
     )
     def get(self, request: Request, *args, **kwargs) -> Response:
         return super().get(request, *args, **kwargs)

--- a/backend/modules/investors/views.py
+++ b/backend/modules/investors/views.py
@@ -160,7 +160,7 @@ class AccountValueOverTimeView(generics.RetrieveAPIView):
         # Generate 120 data points (approximately 4 months of weekly data)
         data_points = []
         today = date.today()
-        base_value = random.uniform(100, 200)
+        base_value = random.uniform(100, 2000)
 
         for i in range(120):
             # Go back in time by weeks
@@ -201,7 +201,7 @@ class CurrentAccountValueView(generics.RetrieveAPIView):
     serializer_class = CurrentAccountValueSerializer
 
     def retrieve(self, request, *args, **kwargs):
-        base_value = 10_000
+        start_account_value = 1000
         # Generate random account value for today, keeping it consistent with
         # the AccountValueOverTimeView endpoint.
         # Using user ID as seed for consistent data per user
@@ -209,18 +209,17 @@ class CurrentAccountValueView(generics.RetrieveAPIView):
 
         # This calculation mimics the first (most recent) value generated
         # in the AccountValueOverTimeView.
-        base_value = random.uniform(100, 200)
+        base_value = random.uniform(100, 2000)
         variation = random.uniform(-0.1, 0.1)  # First variation
         value = base_value * (1 + variation)
 
-        current_value = {"value": round(value, 2)}
-        gain = current_value - base_value
-        gain_percent = gain / base_value
+        gain = value - start_account_value
+        gain_percent = 100 * gain / start_account_value
 
         response = {
-            "current_value" : current_value,
-            "gain" : gain,
-            "gain_percent" : gain_percent
+            "total_account_value" : round(value, 2),
+            "gain" : round(gain,2),
+            "gain_percent" : round(gain_percent,2)
         }
 
         serializer = self.get_serializer(response)
@@ -427,14 +426,14 @@ class TradingOverviewView(generics.RetrieveAPIView):
         random.seed(hash(self.request.user.id))
 
         no_trades = random.randint(5, 20)
-        buys = random.randint(2, no_trades),
+        buys = random.randint(2, no_trades)
         response = {
             "total_trades": no_trades,
             "buys": buys,
             "sells": no_trades - buys,
-            "avg_gain": round(random.uniform(1, 10)),
-            "avg_loss":  round(random.uniform(1, 10)),
-            "total_return":  round(random.uniform(1000, 2000)),
+            "avg_gain": round(random.uniform(1, 50), 2),
+            "avg_loss":  round(random.uniform(1, 50), 2),
+            "total_return":  round(random.uniform(500, 2000), 2),
         }
 
         serializer = self.get_serializer(response)
@@ -473,12 +472,12 @@ class MostTradedOverviewView(generics.RetrieveAPIView):
                 "sells": no_trades - buys,
                 "avg_gain": round(random.uniform(1, 10), 2),
                 "avg_loss": round(random.uniform(1, 10), 2),
-                "total_return": round(random.uniform(1000, 2000), 2),
+                "total_return": round(random.uniform(10, 200), 2),
             }
             instruments.append(instrument)
 
 
-        serializer = self.get_serializer(instruments)
+        serializer = self.get_serializer({"instruments": instruments})
         return Response(serializer.data)
 
     @extend_schema(

--- a/backend/modules/investors/views.py
+++ b/backend/modules/investors/views.py
@@ -16,7 +16,10 @@ from modules.investors.serializers import (
     InvestorSerializer,
     InvestorStatsSerializer,
     InvestorUpdateSerializer,
+    MostTradedOverviewSerializer,
     OwnedSharesSerializer,
+    ProfileOverviewSerializer,
+    TradingOverviewSerializer,
 )
 
 logger = logging.getLogger(__name__)
@@ -198,6 +201,7 @@ class CurrentAccountValueView(generics.RetrieveAPIView):
     serializer_class = CurrentAccountValueSerializer
 
     def retrieve(self, request, *args, **kwargs):
+        base_value = 10_000
         # Generate random account value for today, keeping it consistent with
         # the AccountValueOverTimeView endpoint.
         # Using user ID as seed for consistent data per user
@@ -210,14 +214,22 @@ class CurrentAccountValueView(generics.RetrieveAPIView):
         value = base_value * (1 + variation)
 
         current_value = {"value": round(value, 2)}
+        gain = current_value - base_value
+        gain_percent = gain / base_value
 
-        serializer = self.get_serializer(current_value)
+        response = {
+            "current_value" : current_value,
+            "gain" : gain,
+            "gain_percent" : gain_percent
+        }
+
+        serializer = self.get_serializer(response)
         return Response(serializer.data)
 
     @extend_schema(
         responses={200: CurrentAccountValueSerializer},
         summary="Get current account value",
-        description="Get the current account value for the authenticated user.",
+        description="Get the current account value as well as gain and percent gain for the authenticated user.",
     )
     def get(self, request: Request, *args, **kwargs) -> Response:
         return super().get(request, *args, **kwargs)
@@ -372,6 +384,107 @@ class OwnedSharesView(generics.RetrieveAPIView):
         responses={200: OwnedSharesSerializer},
         summary="Get owned shares",
         description="Get owned shares data for the currently authenticated user.",
+    )
+    def get(self, request: Request, *args, **kwargs) -> Response:
+        return super().get(request, *args, **kwargs)
+
+
+class ProfileOverviewView(generics.RetrieveAPIView):
+    """
+    Get the info about the investor's level.
+    """
+
+    serializer_class = ProfileOverviewSerializer
+
+    def retrieve(self, request, *args, **kwargs):
+        random.seed(hash(self.request.user.id))
+        response = {
+            "level" : "Newbie",
+            "exp_points": random.randint(500, 1000),
+            "left_to_next_level": random.randint(100, 300),
+        }
+
+        serializer = self.get_serializer(response)
+        return Response(serializer.data)
+
+    @extend_schema(
+        responses={200: ProfileOverviewSerializer},
+        summary="Get info about investor's level",
+        description="Get the information about the level, exp points and points left to next level for the current investor",
+    )
+    def get(self, request: Request, *args, **kwargs) -> Response:
+        return super().get(request, *args, **kwargs)
+
+
+class TradingOverviewView(generics.RetrieveAPIView):
+    """
+    Get the trading statistics for the current investor.
+    """
+
+    serializer_class = TradingOverviewSerializer
+
+    def retrieve(self, request, *args, **kwargs):
+        random.seed(hash(self.request.user.id))
+
+        no_trades = random.randint(5, 20)
+        buys = random.randint(2, no_trades),
+        response = {
+            "total_trades": no_trades,
+            "buys": buys,
+            "sells": no_trades - buys,
+            "avg_gain": round(random.uniform(1, 10)),
+            "avg_loss":  round(random.uniform(1, 10)),
+            "total_return":  round(random.uniform(1000, 2000)),
+        }
+
+        serializer = self.get_serializer(response)
+        return Response(serializer.data)
+
+    @extend_schema(
+        responses={200: TradingOverviewSerializer},
+        summary="Get trading performance overview",
+        description="Returns total trades, number of buys/sells, average gain/loss, and total return for the current investor."
+    )
+    def get(self, request: Request, *args, **kwargs) -> Response:
+        return super().get(request, *args, **kwargs)
+
+
+class MostTradedOverviewView(generics.RetrieveAPIView):
+    """
+    Get the statistics for the most traded instruments of the current investor.
+    """
+
+    serializer_class = MostTradedOverviewSerializer
+
+    def retrieve(self, request, *args, **kwargs):
+        random.seed(hash(self.request.user.id))
+
+        instruments = []
+        num_instruments = random.randint(4, 8)
+
+        for i in range(num_instruments):
+            no_trades = random.randint(5, 20)
+            buys = random.randint(3, no_trades)
+
+            instrument = {
+                "symbol": f"SYM{i + 1}",
+                "no_trades": no_trades,
+                "buys": buys,
+                "sells": no_trades - buys,
+                "avg_gain": round(random.uniform(1, 10), 2),
+                "avg_loss": round(random.uniform(1, 10), 2),
+                "total_return": round(random.uniform(1000, 2000), 2),
+            }
+            instruments.append(instrument)
+
+
+        serializer = self.get_serializer(instruments)
+        return Response(serializer.data)
+
+    @extend_schema(
+        responses={200: MostTradedOverviewSerializer},
+        summary="Get overview about the most traded instruments",
+        description="Returns number of trades, number of buys/sells, average gain/loss, and total return from the most frequently traded instruments."
     )
     def get(self, request: Request, *args, **kwargs) -> Response:
         return super().get(request, *args, **kwargs)


### PR DESCRIPTION
Create backend views for mock data required by frontend stats page, so that the mocks can be moved from frontend and actual data querying is going on.

Together with Refactor/move stats mocks #121 from frontend.