### PR TITLE
fix: remove calling django.setup directly

### DIFF
--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,13 +1,6 @@
-import os
-
-import django
-
 from config.celery import app as celery_app
 from config.logging import setup_logging
 
 __all__ = ("celery_app",)
 
 setup_logging()
-
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
-django.setup()

--- a/src/config/asgi.py
+++ b/src/config/asgi.py
@@ -1,12 +1,18 @@
+import os
+
 from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
 from channels.security.websocket import AllowedHostsOriginValidator
 from django.core.asgi import get_asgi_application
 
-from config.urls import websocket_urlpatterns
-from modules.authentication.middlewares import CookieWebsocketAuthMiddleware
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 
 http_application = get_asgi_application()
+
+from config.urls import websocket_urlpatterns  # noqa: E402
+from modules.authentication.middlewares import (  # noqa: E402
+    CookieWebsocketAuthMiddleware,
+)
 
 application = ProtocolTypeRouter(
     {


### PR DESCRIPTION
causes:

```console
Migrating database
Traceback (most recent call last):
  File "/app/manage.py", line 22, in <module>
    main()
    ~~~~^^
  File "/app/manage.py", line 18, in main
    execute_from_command_line(sys.argv)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/app/.venv/lib/python3.13/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
    ~~~~~~~~~~~~~~~^^
  File "/app/.venv/lib/python3.13/site-packages/django/core/management/__init__.py", line 416, in execute
    django.setup()
    ~~~~~~~~~~~~^^
  File "/app/.venv/lib/python3.13/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.13/site-packages/django/apps/registry.py", line 83, in populate
    raise RuntimeError("populate() isn't reentrant")
RuntimeError: populate() isn't reentrant
```

in k8s for some reason