### PR TITLE
feat: avg gain and loss

### DIFF
--- a/src/modules/statistics/serializers.py
+++ b/src/modules/statistics/serializers.py
@@ -106,11 +106,11 @@ class MostTradedItemSerializer(serializers.Serializer):
     # TransactionStats.sell_transactions
     sells = serializers.IntegerField()
 
-    # TransactionStats.gain
-    gain = serializers.FloatField()
+    # TransactionStats.avg_gain
+    avg_gain = serializers.FloatField()
 
-    # TransactionStats.gain_percentage
-    gain_percentage = serializers.FloatField(allow_null=True)
+    # TransactionStats.avg_loss
+    avg_loss = serializers.FloatField()
 
 
 class TransactionHistoryQueryParams(serializers.Serializer):

--- a/src/modules/statistics/services.py
+++ b/src/modules/statistics/services.py
@@ -41,6 +41,8 @@ class TransactionDetails(BaseModel):
 class TransactionStats(BaseModel):
     realized_gain: Decimal
     unrealized_gain: Decimal
+    avg_gain: Decimal
+    avg_loss: Decimal
     total_gain: Decimal
     total_buy_cost: Decimal
     total_sell_cost: Decimal
@@ -161,6 +163,8 @@ class TransactionStatsService:
     def _finalize_stats(
         buy_lots: list[BuyLot],
         realized_gain: Decimal,
+        avg_gain: Decimal,
+        avg_loss: Decimal,
         total_buy_cost: Decimal,
         total_sell_cost: Decimal,
         end_period_price: Decimal,
@@ -198,6 +202,8 @@ class TransactionStatsService:
         return TransactionStats(
             realized_gain=realized_gain,
             unrealized_gain=unrealized_gain,
+            avg_gain=avg_gain,
+            avg_loss=avg_loss,
             total_gain=total_gain,
             total_buy_cost=total_buy_cost,
             total_sell_cost=total_sell_cost,
@@ -218,6 +224,10 @@ class TransactionStatsService:
             for i in initial_buy_lots
         ]
         realized_gain = Decimal(0)
+        gain_sum = Decimal(0)
+        loss_sum = Decimal(0)
+        gain_count = 0
+        loss_count = 0
         total_buy_cost = sum((i.volume * i.price for i in buy_lots), start=Decimal(0))
         total_sell_cost = Decimal(0)
         sell_details: list[SellDetail] = []
@@ -235,6 +245,12 @@ class TransactionStatsService:
                 total_sell_cost += vol * price
                 gain = consumed_volume * price - consumed_cost
                 realized_gain += gain
+                if gain > 0:
+                    gain_sum += gain
+                    gain_count += 1
+                elif gain < 0:
+                    loss_sum += gain
+                    loss_count += 1
                 sell_details.append(
                     SellDetail(
                         volume=consumed_volume,
@@ -248,6 +264,8 @@ class TransactionStatsService:
         return self._finalize_stats(
             buy_lots,
             realized_gain,
+            gain_sum / gain_count if gain_count > 0 else Decimal(0),
+            -(loss_sum / loss_count) if loss_count > 0 else Decimal(0),
             total_buy_cost,
             total_sell_cost,
             end_period_price,

--- a/src/modules/statistics/views.py
+++ b/src/modules/statistics/views.py
@@ -332,10 +332,8 @@ class MostTradedOverviewView(generics.RetrieveAPIView):
                     "no_trades": buy_transactions_count + sell_transactions_count,
                     "buys": buy_transactions_count,
                     "sells": sell_transactions_count,
-                    "gain": round(stat.total_gain, 2),
-                    "gain_percentage": round(stat.total_gain_pct, 2)
-                    if stat.total_gain_pct is not None
-                    else None,
+                    "avg_gain": round(stat.avg_gain, 2),
+                    "avg_loss": round(stat.avg_loss, 2),
                 }
             )
 

--- a/src/schema.yml
+++ b/src/schema.yml
@@ -2554,17 +2554,16 @@ components:
           type: integer
         sells:
           type: integer
-        gain:
+        avg_gain:
           type: number
           format: double
-        gain_percentage:
+        avg_loss:
           type: number
           format: double
-          nullable: true
       required:
+      - avg_gain
+      - avg_loss
       - buys
-      - gain
-      - gain_percentage
       - no_trades
       - sells
       - symbol


### PR DESCRIPTION
test with fronend refactor/avg_gain_loss

calcualtions done in accordance with the following knowledge:
- winning trade is a sell of an asset at a cost better than the buy cost
- avg gain is a sum of gain from the winning trades divided by the number of winning trades

<img width="1345" height="859" alt="image" src="https://github.com/user-attachments/assets/080f861d-b474-4549-9d38-03c4d7c1791d" />

<img width="760" height="179" alt="image" src="https://github.com/user-attachments/assets/2d98a1da-5670-42d3-be45-32e4f62656e0" />

I added the minimal amount of code needed for the sake of time savings. Current tests pass.
